### PR TITLE
Removed vault secret from JSON serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Removed vault secret from JSON serialization.
+
 ## [1.2.0] - 2023-01-18
 
 ### Added

--- a/src/Certificate/AzureKeyVaultCertificateLocator.php
+++ b/src/Certificate/AzureKeyVaultCertificateLocator.php
@@ -156,7 +156,6 @@ class AzureKeyVaultCertificateLocator extends AbstractCertificateLocator impleme
     public function jsonSerialize()
     {
         return parent::jsonSerialize() + [
-                'vaultSecret' => $this->hideSecret($this->vaultSecret),
                 'certificateName' => $this->certificateName,
                 'version' => $this->version,
             ];


### PR DESCRIPTION
Getting a string value from the vault secret involves an HTTP request. We don't want that.
