### PR TITLE
Handled SoapClient options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Changed handling of `SoapClient` options in `AbstractService`.
+
 ## [1.3.0] - 2023-02-03
 
 ### Added

--- a/src/Certificate/AzureKeyVaultCertificateLocator.php
+++ b/src/Certificate/AzureKeyVaultCertificateLocator.php
@@ -53,7 +53,7 @@ class AzureKeyVaultCertificateLocator extends AbstractCertificateLocator impleme
     /**
      * {@inheritDoc}
      */
-    public function getAbsolutePathToCertificate(): string
+    public function getCertificate(): string
     {
         try {
             $secret = $this->vaultSecret->getSecret($this->certificateName, $this->version);
@@ -62,7 +62,16 @@ class AzureKeyVaultCertificateLocator extends AbstractCertificateLocator impleme
         }
 
         $certificateStoreData = $this->getCertificateStoreDataFromSecret($secret->getValue());
-        $certificate = $this->extractCertificateFromStoreData($certificateStoreData);
+
+        return $this->extractCertificateFromStoreData($certificateStoreData);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAbsolutePathToCertificate(): string
+    {
+        $certificate = $this->getCertificate();
 
         return $this->getAbsoluteTmpPathByContent($certificate);
     }

--- a/src/Certificate/CertificateLocatorInterface.php
+++ b/src/Certificate/CertificateLocatorInterface.php
@@ -27,7 +27,14 @@ interface CertificateLocatorInterface
     public function getCertificates(): array;
 
     /**
+     * Get the certificate.
+     */
+    public function getCertificate(): string;
+
+    /**
      * Returns the absolute path to the certificate.
+     *
+     * @deprecated Use self::getCertificate() to get the certificate and store it in a temporary file if needed.
      *
      * @return string the absolute path to the certificate.
      *

--- a/src/Certificate/FilesystemCertificateLocator.php
+++ b/src/Certificate/FilesystemCertificateLocator.php
@@ -53,6 +53,14 @@ class FilesystemCertificateLocator extends AbstractCertificateLocator implements
     }
 
     /**
+     * @return string
+     */
+    public function getCertificate(): string
+    {
+        return file_get_contents($this->pathToCertificate);
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getAbsolutePathToCertificate(): string

--- a/src/Service/AbstractService.php
+++ b/src/Service/AbstractService.php
@@ -10,27 +10,29 @@
 
 namespace ItkDev\Serviceplatformen\Service;
 
+use ItkDev\Serviceplatformen\Certificate\CertificateLocatorInterface;
 use ItkDev\Serviceplatformen\Request\RequestGeneratorInterface;
 use ItkDev\Serviceplatformen\Service\Exception\ServiceException;
 use SoapClient;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class AbstractService
  */
 abstract class AbstractService
 {
-    private $requestGenerator;
-    private $soapClient;
+    private RequestGeneratorInterface $requestGenerator;
+    private array $soapClientOptions;
 
     /**
      * AbstractService constructor.
      *
-     * @param SoapClient $soapClient
+     * @param array $soapClientOptions
      * @param RequestGeneratorInterface $requestGenerator
      */
-    public function __construct(SoapClient $soapClient, RequestGeneratorInterface $requestGenerator)
+    public function __construct(array $soapClientOptions, RequestGeneratorInterface $requestGenerator)
     {
-        $this->soapClient = $soapClient;
+        $this->soapClientOptions = $this->resolveSoapClientOptions($soapClientOptions);
         $this->requestGenerator = $requestGenerator;
     }
 
@@ -48,10 +50,38 @@ abstract class AbstractService
     {
         $request = $this->requestGenerator->makeRequest($message);
 
+        $wsdl = $this->soapClientOptions['wsdl'];
+        $certificateLocator = $this->soapClientOptions['certificate_locator'] ?? null;
+        assert($certificateLocator instanceof CertificateLocatorInterface);
+        $localCertFilename = tempnam(sys_get_temp_dir(), 'cert');
+        file_put_contents($localCertFilename, $certificateLocator->getCertificate());
+
+        $soapClient = new SoapClient($wsdl, $this->soapClientOptions['options']
+            + [
+                'local_cert' => $localCertFilename,
+                'passphrase' => $certificateLocator->getPassphrase()
+            ]);
+
         try {
-            return call_user_func_array([$this->soapClient, $operation], [$request]);
+            return call_user_func_array([$soapClient, $operation], [$request]);
         } catch (\SoapFault $exception) {
             throw new ServiceException($exception->getMessage(), $exception->getCode());
+        } finally {
+            // Remove the certificate from disk.
+            if (file_exists($localCertFilename)) {
+                unlink($localCertFilename);
+            }
         }
+    }
+
+    private function resolveSoapClientOptions(array $option): array
+    {
+        return (new OptionsResolver())
+            ->setRequired('wsdl')
+            ->setRequired('certificate_locator')
+            ->setAllowedTypes('certificate_locator', CertificateLocatorInterface::class)
+            ->setRequired('options')
+            ->setAllowedTypes('options', 'array')
+            ->resolve($option);
     }
 }


### PR DESCRIPTION
Passes SoapClient options to the service rather than an instance of `SoapClient` to fix issue with multiple service certificates overwriting each other or the certificate files being removed before they are actually used.