### PR TITLE
Added XML load helper function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [PR-31](https://github.com/itk-dev/serviceplatformen/pull/31)
+  Added XML load helper function
+
 ## [1.5.1] - 2024-04-24
 
 - [PR-29](https://github.com/itk-dev/serviceplatformen/pull/29)

--- a/src/Command/SF1601/KombiPostAfsendCommand.php
+++ b/src/Command/SF1601/KombiPostAfsendCommand.php
@@ -167,9 +167,8 @@ HELP;
         $meMoMessage = $service->getLastKombiMeMoMessage();
         $io->writeln($meMoMessage->ownerDocument->saveXML($meMoMessage));
 
-        $dom = new DOMDocument();
+        $dom = Serializer::loadXML($response->getContent());
         $dom->formatOutput = true;
-        $dom->loadXML($response->getContent());
 
         $headers = [];
         $length = max(...array_map(static fn (string $name) => strlen($name), array_keys($response->getHeaders())));

--- a/src/Service/SF1500/SF1500.php
+++ b/src/Service/SF1500/SF1500.php
@@ -15,6 +15,7 @@ use ItkDev\Serviceplatformen\Certificate\CertificateLocatorInterface;
 use ItkDev\Serviceplatformen\Service\Exception\SAMLTokenException;
 use ItkDev\Serviceplatformen\Service\Exception\SF1500Exception;
 use ItkDev\Serviceplatformen\Service\SF1514\SF1514;
+use ItkDev\Serviceplatformen\Service\SF1601\Serializer;
 use ItkDev\Serviceplatformen\SF1500\Adresse\ClassMap as AdresseClassMap;
 use ItkDev\Serviceplatformen\SF1500\Adresse\ServiceType\_List as AdresseList;
 use ItkDev\Serviceplatformen\SF1500\Adresse\ServiceType\Laes as AdresseLaes;
@@ -682,8 +683,7 @@ class SF1500
         int $version,
         bool $oneWay = false
     ): string {
-        $doc = new \DOMDocument();
-        $doc->loadXML($request);
+        $doc = Serializer::loadXML($request);
 
         // Set an id.
         /** @var \DOMElement $body */
@@ -764,8 +764,7 @@ class SF1500
     private function preventCaching(string $response): bool
     {
         try {
-            $document = new \DOMDocument();
-            $document->loadXML($response);
+            $document = Serializer::loadXML($response);
             // Prevent caching if we have a SOAP fault.
             if ($document->getElementsByTagNameNS(self::NS_SOAP_ENVELOPE, 'Fault')->count() > 0) {
                 return true;

--- a/src/Service/SF1500/SF1500.php
+++ b/src/Service/SF1500/SF1500.php
@@ -801,13 +801,9 @@ class SF1500
         $now = new \DateTimeImmutable('now');
         $times = [];
         foreach ($this->options['soap_request_cache_expiration_time'] as $spec) {
-            try {
-                $time = $now->modify($spec);
-                if ($time > $now) {
-                    $times[] = $time;
-                }
-            } catch (\Exception $exception) {
-                // Ignore any exceptions.
+            $time = $now->modify($spec);
+            if ($time > $now) {
+                $times[] = $time;
             }
         }
 

--- a/src/Service/SF1500/SF1500XMLBuilder.php
+++ b/src/Service/SF1500/SF1500XMLBuilder.php
@@ -10,6 +10,8 @@
 
 namespace ItkDev\Serviceplatformen\Service\SF1500;
 
+use ItkDev\Serviceplatformen\Service\SF1601\Serializer;
+
 /**
  * Helper class for SF1500 Organisation.
  */
@@ -86,8 +88,7 @@ class SF1500XMLBuilder
         $timestampElement->appendChild($expiresElement);
         $securityElement->appendChild($timestampElement);
 
-        $tokenDocument = new \DOMDocument();
-        $tokenDocument->loadXML($tokenXml);
+        $tokenDocument = Serializer::loadXML($tokenXml);
         $tokenElement = $document->importNode($tokenDocument->documentElement, true);
         $tokenUuid = $this->getElementId($tokenElement);
 
@@ -145,7 +146,7 @@ class SF1500XMLBuilder
         $documentRequest = new \DOMDocument('1.0', 'utf-8');
         $documentRequest->preserveWhiteSpace = false;
         $documentRequest->formatOutput = false;
-        $documentRequest->loadXML($requestSimple);
+        Serializer::loadXML($requestSimple, $documentRequest);
 
         $signatureElement = $documentRequest->getElementsByTagName('Signature')[1];
         $signedInfoElement = $signatureElement->getElementsByTagName('SignedInfo')[0];

--- a/src/Service/SF1514/SF1514.php
+++ b/src/Service/SF1514/SF1514.php
@@ -13,6 +13,7 @@ namespace ItkDev\Serviceplatformen\Service\SF1514;
 use ItkDev\Serviceplatformen\Certificate\CertificateLocatorInterface;
 use ItkDev\Serviceplatformen\Service\Exception\SAMLTokenException;
 use ItkDev\Serviceplatformen\Service\Exception\ServiceException;
+use ItkDev\Serviceplatformen\Service\SF1601\Serializer;
 use ItkDev\Serviceplatformen\Service\SoapClient;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\OptionsResolver\Options;
@@ -338,8 +339,7 @@ class SF1514
      */
     public function parseRequestSecurityTokenResponse($result)
     {
-        $dom = new \DOMDocument();
-        $dom->loadXML($result);
+        $dom = Serializer::loadXML($result);
         $doc = $dom->documentElement;
         $xpath = new \DOMXpath($dom);
         $xpath->registerNamespace('s', 'http://www.w3.org/2003/05/soap-envelope');

--- a/src/Service/SF1601/SF1601.php
+++ b/src/Service/SF1601/SF1601.php
@@ -163,8 +163,7 @@ class SF1601 extends AbstractRESTService
         }
 
         // Build kombi document.
-        $document = new DOMDocument();
-        $document->loadXML('<kombi_request><KombiValgKode/></kombi_request>');
+        $document = Serializer::loadXML('<kombi_request><KombiValgKode/></kombi_request>');
         // Set KombiValgKode.
         $document->documentElement->firstChild->appendChild(new DOMText($type));
 
@@ -193,8 +192,7 @@ class SF1601 extends AbstractRESTService
             }
 
             // Serialize message and import and append it to kombi_request element.
-            $messageDocument = new DOMDocument();
-            $messageDocument->loadXML((new Serializer())->serialize($message));
+            $messageDocument = Serializer::loadXML((new Serializer())->serialize($message));
 
             $document->documentElement->appendChild($document->importNode($messageDocument->documentElement, true));
         }
@@ -202,8 +200,7 @@ class SF1601 extends AbstractRESTService
         if (null !== $forsendelse) {
             $forsendelseSamling = $document->createElementNS('urn:oio:fjernprint:1.0.0', 'ForsendelseISamling');
 
-            $forsendelseDocument = new DOMDocument();
-            $forsendelseDocument->loadXML((new Serializer())->serialize($forsendelse));
+            $forsendelseDocument = Serializer::loadXML((new Serializer())->serialize($forsendelse));
             $forsendelseSamling->appendChild($document->importNode($forsendelseDocument->documentElement, true));
 
             $document->documentElement->appendChild($forsendelseSamling);

--- a/src/Service/SF1601/Serializer.php
+++ b/src/Service/SF1601/Serializer.php
@@ -73,10 +73,23 @@ class Serializer
         return Uuid::v4()->toRfc4122();
     }
 
+    /**
+     * Helper function to load XML into a DOM document.
+     *
+     * We need to be able to handle very long node values (base64 encoded PDF files).
+     */
+    public static function loadXML(string $xml, ?\DOMDocument $document = null): \DOMDocument
+    {
+        $document ??= new DOMDocument();
+
+        $document->loadXML($xml, LIBXML_PARSEHUGE);
+
+        return $document;
+    }
+
     private function normalizeXml(string $xml): string
     {
-        $document = new DOMDocument();
-        $document->loadXML($xml);
+        $document = static::loadXML($xml);
 
         return $document->saveXML();
     }

--- a/src/Service/SoapClient.php
+++ b/src/Service/SoapClient.php
@@ -100,13 +100,9 @@ class SoapClient
         $now = new \DateTimeImmutable('now');
         $times = [];
         foreach ($this->options['cache_expiration_time'] as $spec) {
-            try {
-                $time = $now->modify($spec);
-                if ($time > $now) {
-                    $times[] = $time;
-                }
-            } catch (\Exception $exception) {
-                // Ignore any exceptions.
+            $time = $now->modify($spec);
+            if ($time > $now) {
+                $times[] = $time;
             }
         }
 


### PR DESCRIPTION
Adds (and uses) `loadXML` function in serializer to make sure that we can handle very long node values, e.g. base64 encoded PDF documents.

Cleans up code to satisfy the code analysis.